### PR TITLE
Remove undefined closed variable

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -104,7 +104,7 @@ if (argv.help || argv._[0] === 'help') {
   })
   swarm.on('connection', function (socket, info) {
     pump(socket, drive.replicate(info.client), socket, function (err) {
-      if (!closed) console.error('error=',err)
+      console.error('pump error',err)
     })
     if (!isOpen) open()
   })


### PR DESCRIPTION
`closed` is not defined which causes the server to crash, just log the error as is.

This error happens quite frequently if e.g. a network request times out.